### PR TITLE
replace @st.experimental_fragment with @st.fragment

### DIFF
--- a/pages/Add_Cube_Files.py
+++ b/pages/Add_Cube_Files.py
@@ -66,7 +66,7 @@ def display_cube_file(file_content_text, viz1_html_name, isovalue, opacity):
 
 
 # New feature since streamlit v1.33.0
-@st.experimental_fragment
+@st.fragment
 def show_download_button(summed_file_content):
     st.download_button(
         label="Download summed CUBE file",

--- a/pages/Expand_Cube_File.py
+++ b/pages/Expand_Cube_File.py
@@ -66,7 +66,7 @@ def display_cube_file(file_content_text, viz1_html_name, isovalue, opacity):
 
 
 # New feature since streamlit v1.33.0
-@st.experimental_fragment
+@st.fragment
 def show_download_button(expanded_file_content):
     st.download_button(
         label="Download expanded CUBE file",

--- a/pages/Exponentiate_Cube_File.py
+++ b/pages/Exponentiate_Cube_File.py
@@ -66,7 +66,7 @@ def display_cube_file(file_content_text, viz1_html_name, isovalue, opacity):
 
 
 # New feature since streamlit v1.33.0
-@st.experimental_fragment
+@st.fragment
 def show_download_button(exponentiated_file_content):
     st.download_button(
         label="Download exponentiated CUBE file",

--- a/pages/Multiply_Cube_Files.py
+++ b/pages/Multiply_Cube_Files.py
@@ -66,7 +66,7 @@ def display_cube_file(file_content_text, viz1_html_name, isovalue, opacity):
 
 
 # New feature since streamlit v1.33.0
-@st.experimental_fragment
+@st.fragment
 def show_download_button(multiplied_file_content):
     st.download_button(
         label="Download multiplied CUBE file",

--- a/pages/Planar_Average_of_Cube_File.py
+++ b/pages/Planar_Average_of_Cube_File.py
@@ -65,7 +65,7 @@ def display_cube_file(file_content_text, viz1_html_name, isovalue, opacity):
 
 
 # New feature since streamlit v1.33.0
-@st.experimental_fragment
+@st.fragment
 def show_download_button(df):
     csv = df.to_csv(index=False)
     st.download_button(

--- a/pages/Subtract_Cube_Files.py
+++ b/pages/Subtract_Cube_Files.py
@@ -66,7 +66,7 @@ def display_cube_file(file_content_text, viz1_html_name, isovalue, opacity):
 
 
 # New feature since streamlit v1.33.0
-@st.experimental_fragment
+@st.fragment
 def show_download_button(subtracted_file_content):
     st.download_button(
         label="Download subtracted CUBE file",

--- a/pages/Translate_Cube_File.py
+++ b/pages/Translate_Cube_File.py
@@ -66,7 +66,7 @@ def display_cube_file(file_content_text, viz1_html_name, isovalue, opacity):
 
 
 # New feature since streamlit v1.33.0
-@st.experimental_fragment
+@st.fragment
 def show_download_button(translated_file_content):
     st.download_button(
         label="Download translated CUBE file",


### PR DESCRIPTION
This will fix the issue where two download buttons appear when clicking the button (decorated with `@st.experimental_fragment`).

before:
<img width="392" height="251" alt="image" src="https://github.com/user-attachments/assets/bd12f485-7dc7-45a9-8ac8-28fd9e59cfc1" />

after:
<img width="295" height="198" alt="image" src="https://github.com/user-attachments/assets/af3a7c2c-174c-4502-9dbb-548c882212d1" />
